### PR TITLE
Fixed an issue with the bower config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,9 +7,8 @@
     "webrtc-adapter": "gh-pages"
   },
   "ignore": [
-      "**/.*",
-      "node_modules",
-      "bower_components"
-    ]
-  }
+    "**/.*",
+    "node_modules",
+    "bower_components"
+  ]
 }


### PR DESCRIPTION
Had an extra open bracket that I'm surprised atom didn't catch. Here is a fix.
